### PR TITLE
Add "location" field to CheckPoint

### DIFF
--- a/apiV4/trackings.go
+++ b/apiV4/trackings.go
@@ -35,6 +35,7 @@ type CheckPoint struct {
 	CountryName    string   `json:"country_name,omitempty"`
 	Message        string   `json:"message,omitempty"`
 	State          string   `json:"state,omitempty"`
+	Location       string   `json:"location,omitempty"`
 	Tag            string   `json:"tag,omitempty"`
 	Zip            string   `json:"zip,omitempty"`
 }


### PR DESCRIPTION
For some couriers there exists an undocumented field "location" that contains location info instead of city and coutry. This change allows to get access to this field.