### PR TITLE
Add original http status code to the api-error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -19,6 +19,9 @@ type APIError struct {
 	Type    string `json:"type"`
 	Message string `json:"message"`
 	Path    string `json:"path"`
+
+	// HTTPStatusCode represents the original HTTP status code which was returned by request from Aftership's API
+	HTTPStatusCode int `json:"http_status_code"`
 }
 
 // Error serializes the error object to JSON and returns it as a string.

--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,7 @@ type APIError struct {
 	Message string `json:"message"`
 	Path    string `json:"path"`
 
-	// HTTPStatusCode represents the original HTTP status code which was returned by the request from the AfterShip's API
+	// HTTPStatusCode represents the original HTTP status code which was returned by the request from AfterShip's API
 	HTTPStatusCode int `json:"http_status_code"`
 }
 

--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,7 @@ type APIError struct {
 	Message string `json:"message"`
 	Path    string `json:"path"`
 
-	// HTTPStatusCode represents the original HTTP status code which was returned by request from Aftership's API
+	// HTTPStatusCode represents the original HTTP status code which was returned by the request from the AfterShip's API
 	HTTPStatusCode int `json:"http_status_code"`
 }
 

--- a/request.go
+++ b/request.go
@@ -61,8 +61,8 @@ func (client *Client) makeRequest(ctx context.Context, method string, path strin
 	if err != nil {
 		return errors.Wrap(err, "HTTP request failed")
 	}
-
 	defer resp.Body.Close()
+
 	contents, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, "could not read response body")
@@ -87,10 +87,11 @@ func (client *Client) makeRequest(ctx context.Context, method string, path strin
 	}
 
 	apiError := APIError{
-		Type:    result.Meta.Type,
-		Code:    result.Meta.Code,
-		Message: result.Meta.Message,
-		Path:    path,
+		Type:           result.Meta.Type,
+		Code:           result.Meta.Code,
+		Message:        result.Meta.Message,
+		Path:           path,
+		HTTPStatusCode: resp.StatusCode,
 	}
 
 	// Too many requests error

--- a/request_test.go
+++ b/request_test.go
@@ -3,13 +3,13 @@ package aftership
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
Hey Team!


The issue is current functionality doesn’t allow us to receive the original status HTTP code. We would like to distinguish them easily on our side. We see mapping in your [documentation](https://developers.aftership.com/reference/errors), but in our opinion, it would be great to see the original one.

Also, there are possible missing status codes, which could be occurred during the request, which documentation currently doesn't cover.

What do you think about this suggestion?

This PR is a quick solution. 
For covering all possible cases with returned HTTP status codes, the code should be changed a little bit more. 
1) It's not possible to see the success status code (it should be 201 for the tracking creation)
2) it's not possible to return HTTP status code in cases:
https://github.com/AfterShip/aftership-sdk-go/blob/master/request.go#L81
https://github.com/AfterShip/aftership-sdk-go/blob/master/request.go#L68
https://github.com/AfterShip/aftership-sdk-go/blob/master/request.go#L62

because they are  not a API Error. 

My suggestion to the future: 
make the custom `SDK` error which will include:
1) original error, which happened on the code layer
2) API error, which includes information from Aftership's API
3) HTTP status code.
It will be breaking changes, that's why i implemented only a quick solution.

